### PR TITLE
Update init.vim

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -74,6 +74,8 @@ set wrap
 set ttimeoutlen=0
 set matchpairs+=<:>
 set splitright
+set modelines=0
+set nomodeline
 
 " Safeguard
 if !exists("g:syntax_on")


### PR DESCRIPTION
# Summary
Modelines have had a history of security vulnerabilities, so it best to disable the option explicitly. 

# Changes proposed in this pull request
Disable modelines as a security precaution

# Checklist (if any)

